### PR TITLE
Auto-close right panel when deleting currently viewed optimization result

### DIFF
--- a/app/analysis/page.tsx
+++ b/app/analysis/page.tsx
@@ -423,6 +423,13 @@ export default function RouteAnalysisPage() {
       })
 
       if (response.ok) {
+        // Check if the deleted result is currently being viewed in the right panel
+        if (selectedResult && selectedResult.id === resultToDelete.id) {
+          // Close the right panel since the result being viewed was deleted
+          setSelectedResult(null)
+          setSelectedJobId(null)
+        }
+        
         // Remove the deleted result from the local state
         setOptimizationResults(prev => 
           prev.filter(r => r.id !== resultToDelete.id)


### PR DESCRIPTION
## 🎯 **Right Panel Auto-Close on Delete**

### **Problem Solved**
Previously, when users deleted an optimization result that was currently being viewed in the right panel, the panel would remain open showing the deleted data, creating a poor user experience.

### **Solution Implemented**
- **Smart Detection**: Added logic to check if the deleted result is currently being viewed
- **Auto-Close**: Right panel automatically closes when the viewed result is deleted
- **UI Consistency**: Panel state always matches available data

### **Technical Changes**
**File**: 
**Function**: 



### **User Experience Improvements**
- ✅ **No orphaned panels** after deletion
- ✅ **Automatic cleanup** prevents confusion
- ✅ **Consistent UI state** 
- ✅ **Intuitive behavior**

### **Testing**
- Delete a result while viewing it → Panel closes automatically
- Delete a result while viewing different result → Panel stays open
- All existing delete functionality preserved

### **No Breaking Changes**
All existing functionality remains intact, this is purely a UX improvement.