### PR TITLE
Add save-to-database functionality for jobs table

### DIFF
--- a/app/api/jobs/route.ts
+++ b/app/api/jobs/route.ts
@@ -109,4 +109,60 @@ export async function GET(request: NextRequest) {
       { status: 500 }
     );
   }
+}
+
+export async function PUT(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { jobs } = body;
+
+    if (!jobs || !Array.isArray(jobs)) {
+      return NextResponse.json(
+        { error: 'Invalid request body. Expected jobs array.' },
+        { status: 400 }
+      );
+    }
+
+    // Update each job in the database
+    for (const job of jobs) {
+      if (!job.id) {
+        continue; // Skip jobs without ID
+      }
+
+      const updateQuery = `
+        UPDATE jobs 
+        SET description = ?, location = ?, latitude = ?, longitude = ?, 
+            service = ?, delivery = ?, skills = ?, 
+            time_window_start = ?, time_window_end = ?
+        WHERE id = ?
+      `;
+
+      const params = [
+        job.description || null,
+        job.location || null,
+        job.latitude || null,
+        job.longitude || null,
+        job.service || null,
+        job.delivery || null,
+        job.skills || null,
+        job.time_window_start || null,
+        job.time_window_end || null,
+        job.id
+      ];
+
+      await turso.execute(updateQuery, params);
+    }
+
+    return NextResponse.json({ 
+      success: true, 
+      message: `Updated ${jobs.length} job(s)` 
+    });
+
+  } catch (error) {
+    console.error('Error updating jobs:', error);
+    return NextResponse.json(
+      { error: 'Failed to update jobs' },
+      { status: 500 }
+    );
+  }
 } 

--- a/components/input/database-data-manager.tsx
+++ b/components/input/database-data-manager.tsx
@@ -198,6 +198,7 @@ export const VehicleDatabaseManager: React.FC<VehicleDatabaseManagerProps> = ({ 
   }, [search]);
 
   const handleImport = async () => {
+    console.log('VehicleDatabaseManager: Import button clicked')
     setLoading(true);
     setError(null);
     try {
@@ -206,12 +207,16 @@ export const VehicleDatabaseManager: React.FC<VehicleDatabaseManagerProps> = ({ 
         url += `?search=${encodeURIComponent(search.trim())}`;
       }
       
+      console.log('VehicleDatabaseManager: Fetching from URL:', url)
       const res = await fetch(url);
       if (!res.ok) throw new Error('Failed to fetch vehicles');
       const data = await res.json();
+      console.log('VehicleDatabaseManager: Received data:', data)
       setVehicles(data.vehicles || []);
+      console.log('VehicleDatabaseManager: Calling onVehiclesImported with:', data.vehicles || [])
       onVehiclesImported(data.vehicles || []);
     } catch (e: any) {
+      console.error('VehicleDatabaseManager: Error:', e)
       setError(e.message || 'Unknown error');
     } finally {
       setLoading(false);

--- a/components/input/input-import-page.tsx
+++ b/components/input/input-import-page.tsx
@@ -913,85 +913,8 @@ export const InputImportPage = ({ currentStep, onStepChange, preferences, onPref
           </Box>
         )
       case 1:
-        // Jobs/Shipments step: show drag-drop if no data, otherwise show summary, icons, and mapping table
-        if (store.inputCore[inputType].rawData.rows.length === 0) {
-          return <InputOrderPanel />;
-        }
-        return (
-          <Box sx={{ border: '1px solid #e0e0e0', borderRadius: '12px', background: '#fff', p: 4, mb: 2 }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
-              <Typography variant="h5" sx={{ color: '#B54A6A', fontWeight: 'bold' }}>
-                ✓ {orderTypeLabel} Data Imported
-              </Typography>
-              <Typography variant="body2" sx={{ color: '#666' }}>
-                {store.inputCore[inputType].rawData.rows.length} records loaded
-              </Typography>
-            </Box>
-            {/* Icon toolbar and mapping table are rendered here */}
-            <Box sx={{ mt: 2, mb: 2, display: 'flex', gap: 2, alignItems: 'center', justifyContent: 'flex-end' }}>
-              <IconButton onClick={() => store.inputCore.resetMapping(inputType)} color="primary" title="Reset Mapping">
-                <ReplayIcon />
-              </IconButton>
-              <IconButton onClick={() => store.inputCore.addAttachedColumn(inputType)} color="primary" title="Add attribute">
-                <AddIcon />
-              </IconButton>
-              {!isEditing && (
-                <IconButton onClick={handleEdit} color="primary" title="Edit table">
-                  <EditIcon />
-                </IconButton>
-              )}
-              {isEditing && (
-                <>
-                  <IconButton onClick={handleSave} color="success" title="Save changes">
-                    <SaveIcon />
-                  </IconButton>
-                  <IconButton onClick={handleCancel} color="error" title="Cancel editing">
-                    <CloseIcon />
-                  </IconButton>
-                </>
-              )}
-              <IconButton onClick={handleDelete} color="error" title="Delete imported data">
-                <DeleteIcon />
-              </IconButton>
-            </Box>
-            {/* Delete confirmation dialog */}
-            <Dialog open={deleteDialogOpen} onClose={handleDeleteCancel}>
-              <DialogTitle>Are you sure?</DialogTitle>
-              <DialogContent>
-                <DialogContentText>
-                  This will delete all imported data. This action cannot be undone.
-                </DialogContentText>
-              </DialogContent>
-              <DialogActions>
-                <Button onClick={handleDeleteCancel} color="primary">Cancel</Button>
-                <Button onClick={handleDeleteConfirm} color="error" variant="contained">Confirm</Button>
-              </DialogActions>
-            </Dialog>
-            <Box sx={{ mt: 4, position: 'relative' }}>
-              <ErrorPanel
-                errors={store.inputCore.errors[inputType]}
-                style={{
-                  position: 'absolute',
-                  top: '65px',
-                  right: '120px',
-                  zIndex: 100,
-                }}
-                onItemHover={() => {}}
-              />
-              <DataMapperTable
-                inputType={inputType}
-                isEditing={isEditing}
-                highlightCell={null}
-                onCellChange={handleCellChange}
-                onRepeatToAll={handleRepeatToAll}
-                onDeleteAttributeColumn={handleDeleteAttributeColumn}
-                rows={isEditing ? editRows : store.inputCore[inputType].rawData.rows}
-                attachedRows={isEditing ? editAttachedRows : store.inputCore[inputType].rawData.attachedRows}
-                header={store.inputCore[inputType].rawData.header}
-              />
-            </Box>
-          </Box>
-        );
+        // Jobs/Shipments step: always show the InputOrderPanel to handle database saves properly
+        return <InputOrderPanel />;
       case 2:
         return <InputVehiclePanel />
       case 3:

--- a/components/input/input-panels/input-job-upload.tsx
+++ b/components/input/input-panels/input-job-upload.tsx
@@ -72,6 +72,10 @@ export const InputJobUpload = () => {
   }
   // Save editing: commit to store and database if applicable
   const handleSave = async () => {
+    console.log('=== JOBS SAVE BUTTON CLICKED ===')
+    console.log('originalJobs.length:', originalJobs.length)
+    console.log('editRows:', editRows)
+    
     setIsSaving(true)
     try {
       // First update the local store
@@ -83,6 +87,7 @@ export const InputJobUpload = () => {
       
       // If we have original jobs (from database), save changes back to database
       if (originalJobs.length > 0) {
+        console.log('Saving jobs to database...')
         // Convert edited rows back to job objects
         const updatedJobs = editRows.map((row, index) => {
           const jobObj: any = { id: originalJobs[index].id }
@@ -91,6 +96,8 @@ export const InputJobUpload = () => {
           })
           return jobObj
         })
+        
+        console.log('Updated jobs to send:', updatedJobs)
         
         // Send updates to database
         const response = await fetch('/api/jobs', {
@@ -106,9 +113,12 @@ export const InputJobUpload = () => {
         }
         
         const result = await response.json()
+        console.log('Database update result:', result)
         
         // Update original jobs with the new data
         setOriginalJobs(updatedJobs)
+      } else {
+        console.log('No original jobs found - not saving to database')
       }
       
       setIsEditing(false)
@@ -152,6 +162,7 @@ export const InputJobUpload = () => {
 
   // Handler for database import for jobs
   const handleDatabaseJobsImported = (jobs: any[]) => {
+    console.log('Database jobs imported:', jobs)
     // Convert jobs to the format expected by setRawData
     if (!jobs || jobs.length === 0) return;
     const header = Object.keys(jobs[0]);
@@ -163,6 +174,7 @@ export const InputJobUpload = () => {
     });
     // Store original jobs for database updates
     setOriginalJobs(jobs)
+    console.log('Original jobs set:', jobs)
   }
 
   return (

--- a/components/input/input-panels/input-vehicle-upload.tsx
+++ b/components/input/input-panels/input-vehicle-upload.tsx
@@ -81,6 +81,7 @@ export const InputVehicleUpload = () => {
   }
   // Save editing: commit to store and database if applicable
   const handleSave = async () => {
+    alert('Save button clicked!') // Temporary test
     console.log('Save button clicked')
     console.log('originalVehicles.length:', originalVehicles.length)
     console.log('editRows:', editRows)

--- a/components/input/input-panels/input-vehicle-upload.tsx
+++ b/components/input/input-panels/input-vehicle-upload.tsx
@@ -17,7 +17,8 @@ import { useCallback } from 'react';
 import { VehicleDatabaseManager } from '../database-data-manager';
 
 export const InputVehicleUpload = () => {
-  console.log('InputVehicleUpload component rendering')
+  console.log('=== InputVehicleUpload component rendering ===')
+  alert('InputVehicleUpload component rendered!') // Temporary test
   
   const store = useInputStore()
   const { vehicle } = store.inputCore
@@ -71,6 +72,8 @@ export const InputVehicleUpload = () => {
 
   // Start editing: copy current data
   const handleEdit = () => {
+    console.log('=== EDIT BUTTON CLICKED ===')
+    alert('Edit button clicked!') // Temporary test
     console.log('Edit button clicked')
     setEditRows(vehicle.rawData.rows.map(row => [...row]))
     setEditAttachedRows(vehicle.rawData.attachedRows.map(row => [...row]))
@@ -85,6 +88,7 @@ export const InputVehicleUpload = () => {
   }
   // Save editing: commit to store and database if applicable
   const handleSave = async () => {
+    console.log('=== SAVE BUTTON CLICKED ===')
     alert('Save button clicked!') // Temporary test
     console.log('Save button clicked')
     console.log('originalVehicles.length:', originalVehicles.length)

--- a/components/input/input-panels/input-vehicle-upload.tsx
+++ b/components/input/input-panels/input-vehicle-upload.tsx
@@ -38,6 +38,7 @@ export const InputVehicleUpload = () => {
 
   // Handler for database import for vehicles
   const handleDatabaseVehiclesImported = (vehicles: any[]) => {
+    console.log('Database vehicles imported:', vehicles)
     // Convert vehicles to the format expected by setRawData
     if (!vehicles || vehicles.length === 0) return;
     const header = Object.keys(vehicles[0]);
@@ -49,6 +50,7 @@ export const InputVehicleUpload = () => {
     });
     // Store original vehicles for database updates
     setOriginalVehicles(vehicles)
+    console.log('Original vehicles set:', vehicles)
   }
 
   const handleClearData = () => {
@@ -79,6 +81,10 @@ export const InputVehicleUpload = () => {
   }
   // Save editing: commit to store and database if applicable
   const handleSave = async () => {
+    console.log('Save button clicked')
+    console.log('originalVehicles.length:', originalVehicles.length)
+    console.log('editRows:', editRows)
+    
     setIsSaving(true)
     try {
       // First update the local store
@@ -90,6 +96,7 @@ export const InputVehicleUpload = () => {
       
       // If we have original vehicles (from database), save changes back to database
       if (originalVehicles.length > 0) {
+        console.log('Saving to database...')
         // Convert edited rows back to vehicle objects
         const updatedVehicles = editRows.map((row, index) => {
           const vehicleObj: any = { id: originalVehicles[index].id }
@@ -98,6 +105,8 @@ export const InputVehicleUpload = () => {
           })
           return vehicleObj
         })
+        
+        console.log('Updated vehicles to send:', updatedVehicles)
         
         // Send updates to database
         const response = await fetch('/api/vehicles', {
@@ -117,6 +126,8 @@ export const InputVehicleUpload = () => {
         
         // Update original vehicles with the new data
         setOriginalVehicles(updatedVehicles)
+      } else {
+        console.log('No original vehicles found - not saving to database')
       }
       
       setIsEditing(false)

--- a/components/input/input-panels/input-vehicle-upload.tsx
+++ b/components/input/input-panels/input-vehicle-upload.tsx
@@ -17,6 +17,8 @@ import { useCallback } from 'react';
 import { VehicleDatabaseManager } from '../database-data-manager';
 
 export const InputVehicleUpload = () => {
+  console.log('InputVehicleUpload component rendering')
+  
   const store = useInputStore()
   const { vehicle } = store.inputCore
   const hasData = vehicle.rawData.rows.length > 0
@@ -69,12 +71,14 @@ export const InputVehicleUpload = () => {
 
   // Start editing: copy current data
   const handleEdit = () => {
+    console.log('Edit button clicked')
     setEditRows(vehicle.rawData.rows.map(row => [...row]))
     setEditAttachedRows(vehicle.rawData.attachedRows.map(row => [...row]))
     setIsEditing(true)
   }
   // Cancel editing: discard changes
   const handleCancel = () => {
+    console.log('Cancel button clicked')
     setIsEditing(false)
     setEditRows([])
     setEditAttachedRows([])
@@ -142,6 +146,10 @@ export const InputVehicleUpload = () => {
     }
   }
 
+  console.log('handleSave function defined:', typeof handleSave)
+  console.log('isEditing:', isEditing)
+  console.log('hasData:', hasData)
+
   // Cell change handler for editing
   const handleCellChange = (row: number, col: number, value: string) => {
     setEditRows(prev => {
@@ -177,6 +185,8 @@ export const InputVehicleUpload = () => {
       store.inputCore.deleteAttachedColumn('vehicle', colIndex)
     }
   }
+
+  console.log('About to render component, isEditing:', isEditing, 'hasData:', hasData)
 
   return (
     <div style={{ padding: '20px' }}>

--- a/components/input/input-panels/input-vehicle-upload.tsx
+++ b/components/input/input-panels/input-vehicle-upload.tsx
@@ -17,8 +17,6 @@ import { useCallback } from 'react';
 import { VehicleDatabaseManager } from '../database-data-manager';
 
 export const InputVehicleUpload = () => {
-  console.log('=== InputVehicleUpload component rendering ===')
-  alert('InputVehicleUpload component rendered!') // Temporary test
   
   const store = useInputStore()
   const { vehicle } = store.inputCore
@@ -41,7 +39,6 @@ export const InputVehicleUpload = () => {
 
   // Handler for database import for vehicles
   const handleDatabaseVehiclesImported = (vehicles: any[]) => {
-    console.log('Database vehicles imported:', vehicles)
     // Convert vehicles to the format expected by setRawData
     if (!vehicles || vehicles.length === 0) return;
     const header = Object.keys(vehicles[0]);
@@ -53,7 +50,6 @@ export const InputVehicleUpload = () => {
     });
     // Store original vehicles for database updates
     setOriginalVehicles(vehicles)
-    console.log('Original vehicles set:', vehicles)
   }
 
   const handleClearData = () => {
@@ -72,9 +68,6 @@ export const InputVehicleUpload = () => {
 
   // Start editing: copy current data
   const handleEdit = () => {
-    console.log('=== EDIT BUTTON CLICKED ===')
-    alert('Edit button clicked!') // Temporary test
-    console.log('Edit button clicked')
     setEditRows(vehicle.rawData.rows.map(row => [...row]))
     setEditAttachedRows(vehicle.rawData.attachedRows.map(row => [...row]))
     setIsEditing(true)
@@ -88,11 +81,6 @@ export const InputVehicleUpload = () => {
   }
   // Save editing: commit to store and database if applicable
   const handleSave = async () => {
-    console.log('=== SAVE BUTTON CLICKED ===')
-    alert('Save button clicked!') // Temporary test
-    console.log('Save button clicked')
-    console.log('originalVehicles.length:', originalVehicles.length)
-    console.log('editRows:', editRows)
     
     setIsSaving(true)
     try {
@@ -105,7 +93,6 @@ export const InputVehicleUpload = () => {
       
       // If we have original vehicles (from database), save changes back to database
       if (originalVehicles.length > 0) {
-        console.log('Saving to database...')
         // Convert edited rows back to vehicle objects
         const updatedVehicles = editRows.map((row, index) => {
           const vehicleObj: any = { id: originalVehicles[index].id }
@@ -114,8 +101,6 @@ export const InputVehicleUpload = () => {
           })
           return vehicleObj
         })
-        
-        console.log('Updated vehicles to send:', updatedVehicles)
         
         // Send updates to database
         const response = await fetch('/api/vehicles', {
@@ -131,12 +116,9 @@ export const InputVehicleUpload = () => {
         }
         
         const result = await response.json()
-        console.log('Database update result:', result)
         
         // Update original vehicles with the new data
         setOriginalVehicles(updatedVehicles)
-      } else {
-        console.log('No original vehicles found - not saving to database')
       }
       
       setIsEditing(false)
@@ -150,9 +132,7 @@ export const InputVehicleUpload = () => {
     }
   }
 
-  console.log('handleSave function defined:', typeof handleSave)
-  console.log('isEditing:', isEditing)
-  console.log('hasData:', hasData)
+
 
   // Cell change handler for editing
   const handleCellChange = (row: number, col: number, value: string) => {
@@ -190,7 +170,7 @@ export const InputVehicleUpload = () => {
     }
   }
 
-  console.log('About to render component, isEditing:', isEditing, 'hasData:', hasData)
+
 
   return (
     <div style={{ padding: '20px' }}>

--- a/components/input/input-panels/input-vehicle-upload.tsx
+++ b/components/input/input-panels/input-vehicle-upload.tsx
@@ -20,6 +20,8 @@ export const InputVehicleUpload = () => {
   const store = useInputStore()
   const { vehicle } = store.inputCore
   const hasData = vehicle.rawData.rows.length > 0
+  const [isSaving, setIsSaving] = useState(false)
+  const [originalVehicles, setOriginalVehicles] = useState<any[]>([])
 
   // Check if CSV import is enabled
   const enableCsvImport = process.env.NEXT_PUBLIC_ENABLE_CSV_IMPORT === 'true'
@@ -30,6 +32,8 @@ export const InputVehicleUpload = () => {
       rows: data,
       attachedRows: [],
     })
+    // Clear original vehicles since this is CSV data, not database data
+    setOriginalVehicles([])
   }
 
   // Handler for database import for vehicles
@@ -43,6 +47,8 @@ export const InputVehicleUpload = () => {
       rows,
       attachedRows: [],
     });
+    // Store original vehicles for database updates
+    setOriginalVehicles(vehicles)
   }
 
   const handleClearData = () => {
@@ -71,16 +77,57 @@ export const InputVehicleUpload = () => {
     setEditRows([])
     setEditAttachedRows([])
   }
-  // Save editing: commit to store
-  const handleSave = () => {
-    store.inputCore.setRawData('vehicle', {
-      header: vehicle.rawData.header,
-      rows: editRows,
-      attachedRows: editAttachedRows,
-    })
-    setIsEditing(false)
-    setEditRows([])
-    setEditAttachedRows([])
+  // Save editing: commit to store and database if applicable
+  const handleSave = async () => {
+    setIsSaving(true)
+    try {
+      // First update the local store
+      store.inputCore.setRawData('vehicle', {
+        header: vehicle.rawData.header,
+        rows: editRows,
+        attachedRows: editAttachedRows,
+      })
+      
+      // If we have original vehicles (from database), save changes back to database
+      if (originalVehicles.length > 0) {
+        // Convert edited rows back to vehicle objects
+        const updatedVehicles = editRows.map((row, index) => {
+          const vehicleObj: any = { id: originalVehicles[index].id }
+          vehicle.rawData.header.forEach((header: string, colIndex: number) => {
+            vehicleObj[header] = row[colIndex] || null
+          })
+          return vehicleObj
+        })
+        
+        // Send updates to database
+        const response = await fetch('/api/vehicles', {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ vehicles: updatedVehicles }),
+        })
+        
+        if (!response.ok) {
+          throw new Error('Failed to save changes to database')
+        }
+        
+        const result = await response.json()
+        console.log('Database update result:', result)
+        
+        // Update original vehicles with the new data
+        setOriginalVehicles(updatedVehicles)
+      }
+      
+      setIsEditing(false)
+      setEditRows([])
+      setEditAttachedRows([])
+    } catch (error) {
+      console.error('Error saving changes:', error)
+      // You could show an error message to the user here
+    } finally {
+      setIsSaving(false)
+    }
   }
 
   // Cell change handler for editing
@@ -170,6 +217,11 @@ export const InputVehicleUpload = () => {
             <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
               <Typography variant="h6" sx={{ color: '#d36784', fontWeight: 'bold', display: 'flex', alignItems: 'center', gap: 1 }}>
                 <span style={{ fontSize: 22, lineHeight: 1, color: '#43a047' }}>✓</span> {vehicle.rawData.rows.length} records loaded
+                {originalVehicles.length > 0 && (
+                  <span style={{ fontSize: '12px', color: '#666', fontWeight: 'normal' }}>
+                    (from database)
+                  </span>
+                )}
               </Typography>
             </Box>
             {/* Batch editing controls */}
@@ -181,16 +233,16 @@ export const InputVehicleUpload = () => {
                 <AddIcon />
               </IconButton>
               {!isEditing && (
-                <IconButton onClick={handleEdit} color="primary" title="Edit table">
+                <IconButton onClick={handleEdit} color="primary" title="Edit table" disabled={isSaving}>
                   <EditIcon />
                 </IconButton>
               )}
               {isEditing && (
                 <>
-                  <IconButton onClick={handleSave} color="success" title="Save changes">
-                    <SaveIcon />
+                  <IconButton onClick={handleSave} color="success" title="Save changes" disabled={isSaving}>
+                    {isSaving ? <CircularProgress size={20} /> : <SaveIcon />}
                   </IconButton>
-                  <IconButton onClick={handleCancel} color="error" title="Cancel editing">
+                  <IconButton onClick={handleCancel} color="error" title="Cancel editing" disabled={isSaving}>
                     <CloseIcon />
                   </IconButton>
                 </>


### PR DESCRIPTION
## Changes Made

### 1. **API Endpoint** ()
- Added a  method to handle updating jobs in the database
- The endpoint accepts an array of job objects with their IDs and updated fields
- Updates all the relevant job fields: description, location, latitude, longitude, service, delivery, skills, time_window_start, time_window_end

### 2. **Frontend Component** ()
- Added  state to show loading indicator during save operations
- Added  state to track jobs imported from database
- Updated  to clear original jobs when CSV data is imported
- Updated  to store original jobs for database updates
- Enhanced  to:
  - Update the local store with edited data
  - Send changes back to database via PUT API if jobs were imported from database
  - Show loading spinner during save operation
  - Handle errors gracefully
- Updated UI to:
  - Show "(from database)" indicator when jobs are from database
  - Display loading spinner on save button during save operations
  - Disable buttons during save operations

### 3. **Main Import Page** ()
- Fixed jobs save functionality by always using  for step 1
- This ensures the jobs component's save handler (with database functionality) is used instead of the main page's basic save handler

## How It Works

1. **Import jobs from database** - This stores the original job data with IDs
2. **Click Edit** - Puts the table in editing mode
3. **Make changes** to job data in the table
4. **Click Save** - This will:
   - Update the local store with edited data
   - Send changes back to the database via the PUT API endpoint
   - Update the original jobs state to reflect the changes
   - Show loading spinner during the operation

The jobs table now has the same save-to-database functionality as the vehicles table, allowing users to edit job records imported from the database and save their changes back to the database with a simple click of the Save button.