### PR TITLE
UI improvements: Fix table column widths, update HAZMAT labels, and improve routing panel

### DIFF
--- a/components/common/route-summary-table.tsx
+++ b/components/common/route-summary-table.tsx
@@ -214,8 +214,7 @@ export const RouteSummaryTable: React.FC<RouteSummaryTableProps> = ({
             <TableCell sx={{ width: 80, minWidth: 80 }}><strong>Stops</strong></TableCell>
             <TableCell sx={{ width: 100, minWidth: 100 }}><strong>Distance</strong></TableCell>
             <TableCell sx={{ width: 100, minWidth: 100 }}><strong>Drive</strong></TableCell>
-            <TableCell sx={{ width: 120, minWidth: 120 }}><strong>Delivery</strong></TableCell>
-            <TableCell sx={{ width: 140, minWidth: 140 }}><strong>Departure</strong></TableCell>
+            <TableCell sx={{ width: 180, minWidth: 180 }}><strong>Fuel Delivery</strong></TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -282,13 +281,13 @@ export const RouteSummaryTable: React.FC<RouteSummaryTableProps> = ({
                 <TableCell onClick={() => handleToggleRoute(routeIndex)}>
                   {route.delivery && route.delivery.length >= 2 ? (
                     <Box sx={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
-                      <Typography variant="body2" sx={{ display: 'block', color: '#666', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: '0.875rem' }}>
+                      <Typography variant="body2" sx={{ display: 'block', color: '#666', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: '0.75rem' }}>
                         ULSD Clear: {route.delivery[0]} gal
                       </Typography>
-                      <Typography variant="body2" sx={{ display: 'block', color: '#666', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: '0.875rem' }}>
+                      <Typography variant="body2" sx={{ display: 'block', color: '#666', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: '0.75rem' }}>
                         ULSD Dyed: {route.delivery[1]} gal
                       </Typography>
-                      <Typography variant="body2" sx={{ display: 'block', fontWeight: 'bold', color: companyColor, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: '0.875rem' }}>
+                      <Typography variant="body2" sx={{ display: 'block', fontWeight: 'bold', color: companyColor, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: '0.75rem' }}>
                         Total: {route.delivery[0] + route.delivery[1] + route.delivery[2] + route.delivery[3] + route.delivery[4]} gal
                       </Typography>
                     </Box>
@@ -302,26 +301,10 @@ export const RouteSummaryTable: React.FC<RouteSummaryTableProps> = ({
                     </Typography>
                   )}
                 </TableCell>
-                <TableCell onClick={() => handleToggleRoute(routeIndex)}>
-                  <Typography variant="body2" sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                    {(() => {
-                      const startLoad = route.steps && route.steps[0] && route.steps[0].load;
-                      const capacity = route.capacity;
-                      if (Array.isArray(startLoad) && Array.isArray(capacity) && capacity.length > 0) {
-                        const totalLoad = startLoad.reduce((a: number, b: number) => a + b, 0);
-                        const totalCapacity = capacity.reduce((a: number, b: number) => a + b, 0);
-                        if (totalCapacity > 0) {
-                          const percent = (totalLoad / totalCapacity) * 100;
-                          return percent.toFixed(1) + '%';
-                        }
-                      }
-                      return '-';
-                    })()}
-                  </Typography>
-                </TableCell>
+
               </TableRow>
               <TableRow>
-                <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={showSelection ? 11 : 10}>
+                <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={showSelection ? 10 : 9}>
                   <Collapse in={expandedRoutes.has(routeIndex)} timeout="auto" unmountOnExit>
                     <Box sx={{ margin: 1 }}>
                       <Typography variant="h6" gutterBottom component="div">
@@ -373,13 +356,13 @@ export const RouteSummaryTable: React.FC<RouteSummaryTableProps> = ({
                                 <TableCell sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                                   {step.load && step.load.length >= 2 ? (
                                     <Box>
-                                      <Typography variant="body2" sx={{ display: 'block', color: '#666', fontSize: '0.875rem' }}>
+                                      <Typography variant="body2" sx={{ display: 'block', color: '#666', fontSize: '0.75rem' }}>
                                         ULSD Clear: {step.load[0]} gal
                                       </Typography>
-                                      <Typography variant="body2" sx={{ display: 'block', color: '#666', fontSize: '0.875rem' }}>
+                                      <Typography variant="body2" sx={{ display: 'block', color: '#666', fontSize: '0.75rem' }}>
                                         ULSD Dyed: {step.load[1]} gal
                                       </Typography>
-                                      <Typography variant="body2" sx={{ display: 'block', fontWeight: 'bold', color: companyColor, fontSize: '0.875rem' }}>
+                                      <Typography variant="body2" sx={{ display: 'block', fontWeight: 'bold', color: companyColor, fontSize: '0.75rem' }}>
                                         Total: {step.load[0] + step.load[1]} gal
                                       </Typography>
                                     </Box>

--- a/components/input/input-panels/routing-panel.tsx
+++ b/components/input/input-panels/routing-panel.tsx
@@ -33,6 +33,7 @@ const AVOID_OPTIONS = [
 ]
 
 const HAZMAT_OPTIONS = [
+  {label: 'None', value: 'none', internalValues: []},
   {label: 'Class 1 (Explosives)', value: 'class_1', internalValues: ['circumstantial', 'general', 'explosive']},
   {label: 'Class 2 (Gas)', value: 'class_2', internalValues: ['circumstantial', 'general', 'explosive']},
   {label: 'Class 3 (Flammable Liquid)', value: 'class_3', internalValues: ['circumstantial', 'general', 'explosive', 'harmful_to_water']},
@@ -82,6 +83,8 @@ export function RoutingPanel({ preferences, onPreferencesChange }: RoutingPanelP
           mode: value,
           truck_size: '',
           truck_weight: 0,
+          selected_hazmat_class: 'none',
+          hazmat_type: [],
         },
       })
     } else {
@@ -140,19 +143,6 @@ export function RoutingPanel({ preferences, onPreferencesChange }: RoutingPanelP
   const setHazmatTypes = (value: string | string[]) => {
     // Handle single selection - if it's a string, convert to array
     const selectedValues = Array.isArray(value) ? value : [value]
-    
-    // If no values selected, clear the setting
-    if (selectedValues.length === 0) {
-      onPreferencesChange({
-        ...preferences,
-        routing: {
-          ...routing,
-          hazmat_type: undefined,
-          selected_hazmat_class: undefined,
-        },
-      })
-      return
-    }
     
     // Take only the first selected value (single selection)
     const selectedValue = selectedValues[0]
@@ -305,21 +295,14 @@ export function RoutingPanel({ preferences, onPreferencesChange }: RoutingPanelP
               <FormControl fullWidth size="small">
                 <InputLabel>{t('preferences.hazardousMaterialTypes')}</InputLabel>
                 <Select
-                  value={routing.selected_hazmat_class || ''}
+                  value={routing.selected_hazmat_class || 'none'}
                   onChange={(e) => setHazmatTypes(e.target.value)}
                   input={<OutlinedInput label={t('preferences.hazardousMaterialTypes')} />}
-                  displayEmpty
                   renderValue={(selected: string) => {
-                    if (!selected) {
-                      return <span style={{ color: '#999' }}>{t('preferences.selectHazardClass')}</span>
-                    }
                     const option = HAZMAT_OPTIONS.find(opt => opt.value === selected)
                     return option?.label || selected
                   }}
                 >
-                  <MenuItem value="">
-                    <em>{t('preferences.clearSelection')}</em>
-                  </MenuItem>
                   {HAZMAT_OPTIONS.map((option) => (
                     <MenuItem key={option.value} value={option.value}>
                       {option.label}

--- a/contexts/language-context.tsx
+++ b/contexts/language-context.tsx
@@ -239,7 +239,7 @@ const enTranslations = {
     "clearPreferences": "Clear Preferences",
     "routingOptions": "Routing Options",
     "avoidOptions": "Avoid Options",
-    "hazmatTypes": "Hazardous Material Types",
+
     "truckMode": "Truck Mode",
     "carMode": "Car Mode",
     "bikeMode": "Bike Mode",
@@ -262,7 +262,7 @@ const enTranslations = {
     "truckSizeHelperText": "Invalid truck size, e.g. 10,10,10",
     "truckWeight": "Truck weight",
     "routeAvoidances": "Route Avoidances",
-    "hazardousMaterialTypes": "Hazardous Material Types",
+    "hazardousMaterialTypes": "HAZMAT",
     "selectHazardClass": "Select hazard class...",
     "clearSelection": "Clear selection"
   },
@@ -626,7 +626,6 @@ const esMxTranslations = {
     "clearPreferences": "Limpiar Preferencias",
     "routingOptions": "Opciones de Enrutamiento",
     "avoidOptions": "Opciones de Evitar",
-    "hazmatTypes": "Tipos de Materiales Peligrosos",
     "truckMode": "Modo Camión",
     "carMode": "Modo Auto",
     "bikeMode": "Modo Bicicleta",
@@ -649,7 +648,7 @@ const esMxTranslations = {
     "truckSizeHelperText": "Tamaño de camión inválido, ej. 10,10,10",
     "truckWeight": "Peso del camión",
     "routeAvoidances": "Evitaciones de Ruta",
-    "hazardousMaterialTypes": "Tipos de Materiales Peligrosos",
+    "hazardousMaterialTypes": "HAZMAT",
     "selectHazardClass": "Seleccionar clase de peligro...",
     "clearSelection": "Limpiar selección"
   },
@@ -1013,7 +1012,6 @@ const ptBrTranslations = {
     "clearPreferences": "Limpar Preferências",
     "routingOptions": "Opções de Roteamento",
     "avoidOptions": "Opções de Evitar",
-    "hazmatTypes": "Tipos de Materiais Perigosos",
     "truckMode": "Modo Caminhão",
     "carMode": "Modo Carro",
     "bikeMode": "Modo Bicicleta",
@@ -1036,7 +1034,7 @@ const ptBrTranslations = {
     "truckSizeHelperText": "Tamanho de caminhão inválido, ex. 10,10,10",
     "truckWeight": "Peso do caminhão",
     "routeAvoidances": "Evitamentos de Rota",
-    "hazardousMaterialTypes": "Tipos de Materiais Perigosos",
+    "hazardousMaterialTypes": "HAZMAT",
     "selectHazardClass": "Selecionar classe de perigo...",
     "clearSelection": "Limpar seleção"
   },
@@ -1400,7 +1398,6 @@ const caFrTranslations = {
     "clearPreferences": "Effacer les Préférences",
     "routingOptions": "Options de Routage",
     "avoidOptions": "Options d'Évitement",
-    "hazmatTypes": "Types de Matières Dangereuses",
     "truckMode": "Mode Camion",
     "carMode": "Mode Voiture",
     "bikeMode": "Mode Vélo",
@@ -1423,7 +1420,7 @@ const caFrTranslations = {
     "truckSizeHelperText": "Taille de camion invalide, ex. 10,10,10",
     "truckWeight": "Poids du camion",
     "routeAvoidances": "Évitements de Route",
-    "hazardousMaterialTypes": "Types de Matières Dangereuses",
+    "hazardousMaterialTypes": "HAZMAT",
     "selectHazardClass": "Sélectionner la classe de danger...",
     "clearSelection": "Effacer la sélection"
   },


### PR DESCRIPTION
## Summary

This PR includes several UI improvements to enhance the user experience:

### Table Improvements
- **Increased Fuel Delivery column width** from 120px to 180px to prevent content clipping
- **Removed unnecessary Departure column** from route summary table to focus on essential information
- **Reduced font size** in delivery columns from 0.875rem to 0.75rem for better content fit
- **Updated colspan values** to account for the removed column

### HAZMAT Label Updates
- **Changed 'Hazardous Material Types' to 'HAZMAT'** across all supported languages (English, Spanish, Portuguese, French Canadian)
- **Fixed duplicate property issues** in the language context file
- **Maintained consistency** across all i18n translations

### Routing Panel Improvements
- **Added 'None' as default HAZMAT option** to provide a clear default selection
- **Removed helper text** from the HAZMAT dropdown for a cleaner interface
- **Updated default behavior** to automatically set HAZMAT to 'None' when truck mode is selected

### Files Modified
-  - Table layout and styling improvements
-  - HAZMAT selection improvements
-  - i18n label updates

These changes improve the overall usability and visual clarity of the route planning interface.