### PR TITLE
fix: Remove debug styling from Use Depot checkbox

### DIFF
--- a/components/input/input-panels/routing-panel.tsx
+++ b/components/input/input-panels/routing-panel.tsx
@@ -82,7 +82,7 @@ export function RoutingPanel({ preferences, onPreferencesChange }: RoutingPanelP
   console.log('RoutingPanel rendered with preferences:', preferences)
   console.log('Routing preferences:', routing)
   console.log('Use Depot checkbox value:', routing.use_depot)
-  console.log('🔍 DEPOT CHECKBOX TEST - Component should be visible with red border and yellow background')
+
 
   const setTransportMode = (value: string) => {
     if (value === 'truck') {
@@ -251,10 +251,7 @@ export function RoutingPanel({ preferences, onPreferencesChange }: RoutingPanelP
               label={t('preferences.useDepot') || 'Use Depot'}
               sx={{ 
                 fontSize: '1rem',
-                fontWeight: '500',
-                border: '2px solid red',
-                padding: '10px',
-                backgroundColor: 'yellow'
+                fontWeight: '500'
               }}
             />
           </Grid>


### PR DESCRIPTION
## Clean Fix for Use Depot Checkbox

### Issue Resolved
The Use Depot checkbox was confirmed to be working with debug styling (red border, yellow background). This PR removes the debug styling and provides a clean, functional checkbox.

### Changes Made
- Removed red border and yellow background debug styling
- Removed debug console log message
- Kept the functional Use Depot checkbox with proper styling
- Maintained the 1.5rem icon size and 1rem font weight for good visibility

### Result
The Use Depot checkbox now appears with:
- Clean, professional styling
- Proper visibility without debug colors
- Full functionality for depot routing
- Integration with Depot Runs text field

### Testing
✅ Confirmed checkbox is visible and functional
✅ Debug styling successfully identified the component
✅ Clean styling maintains usability

### Files Modified
-  - Removed debug styling